### PR TITLE
Set width and height of SVG

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,8 +27,11 @@
         const translate = (1 - Number.parseFloat(scale)) * 300;
         t.setAttribute('transform', `translate(${translate}, ${translate}), scale(${scale})`);
       });
+      svgClone.width.baseVal.valueAsString = svgClone.width.baseVal.value.toString();
+      svgClone.height.baseVal.valueAsString = svgClone.height.baseVal.value.toString();
       const svgXML = (new XMLSerializer).serializeToString(svgClone);
-      loader.src = 'data:image/svg+xml;base64,' + btoa(svgXML);
+      const base64EncodedSVG = 'data:image/svg+xml;base64,' + btoa(svgXML);
+      loader.src = base64EncodedSVG;
     }
     function downloadWheelOfLife(base64) {
       const link = document.createElement('a');


### PR DESCRIPTION
This sets the width and height property of the svg dom document to fix bug #9 where Firefox wouldn't render the svg on the canvas if those properties a missing.